### PR TITLE
prise en compte de plus de consonnes muettes

### DIFF
--- a/addok_fr/utils.py
+++ b/addok_fr/utils.py
@@ -9,6 +9,8 @@ def phonemicize(s):
     if s not in _CACHE:
         rules = (
             ("a(mp|nd|nt)s?$", "an"), # champ(s) > cham
+            (r"ngt([aeiouy])", r"nt\1"),  # vingtieme > vintieme
+            (r"ngt", "n"),  # vingt > vin
             ("((?<=[^g])g|^g)(?=[eyi])", "j"),
             ("(?<=g)u(?=[aeio])", ""),
             ("c(?=[^hieyw])", "k"),

--- a/addok_fr/utils.py
+++ b/addok_fr/utils.py
@@ -8,7 +8,7 @@ def phonemicize(s):
     significant."""
     if s not in _CACHE:
         rules = (
-            ("a(mp|nd|nt)s?$", "an"), # champ(s) > cham
+            ("a(mp|nd|nt)s?$", "an"),  # champ(s) > cham
             (r"ngt([aeiouy])", r"nt\1"),  # vingtieme > vintieme
             (r"ngt", "n"),  # vingt > vin
             ("((?<=[^g])g|^g)(?=[eyi])", "j"),
@@ -39,7 +39,7 @@ def phonemicize(s):
             ("(?<=[aeiou])(m)(?=[pbgft])", "n"),
             ("(?<=[a-z]{2})(e$)", ""),  # Remove "e" at last position only if
                                         # it follows two letters?
-            ("([aeiouy])n[dt]([^aeiouyr])", "\\1n\\2"), # montbon -> monbon
+            ("([aeiouy])n[dt]([^aeiouyr])", "\\1n\\2"),  # montbon -> monbon
             (r"([a-z])\1", r"\1"),  # Remove duplicate letters.
         )
         _s = s

--- a/addok_fr/utils.py
+++ b/addok_fr/utils.py
@@ -8,6 +8,7 @@ def phonemicize(s):
     significant."""
     if s not in _CACHE:
         rules = (
+            ("a(mp|nd|nt)s?$", "an"), # champ(s) > cham
             ("((?<=[^g])g|^g)(?=[eyi])", "j"),
             ("(?<=g)u(?=[aeio])", ""),
             ("c(?=[^hieyw])", "k"),
@@ -33,13 +34,15 @@ def phonemicize(s):
             ("(?<=u)lt$", "t"),
             ("(?<=[a-z])[dg]$", ""),
             ("(?<=[^es0-9])t$", ""),
-            ("(?<=[aeiou])(m)(?=[pbgf])", "n"),
+            ("(?<=[aeiou])(m)(?=[pbgft])", "n"),
             ("(?<=[a-z]{2})(e$)", ""),  # Remove "e" at last position only if
                                         # it follows two letters?
-            ("(\\D)(?=\\1)", ""),  # Remove duplicate letters.
+            ("([aeiouy])n[dt]([^aeiouyr])", "\\1n\\2"), # montbon -> monbon
+            (r"([a-z])\1", r"\1"),  # Remove duplicate letters.
         )
         _s = s
         for pattern, repl in rules:
             _s = re.sub(pattern, repl, _s)
+#            print(pattern, _s)
         _CACHE[s] = _s
     return s.update(_CACHE[s])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -109,6 +109,8 @@ from addok_fr.utils import phonemicize
     ['montage', 'montaj'],
     ['champs', 'chan'],
     ['grandchamps', 'granchan'],
+    ['vingt', 'vin'],
+    ['vingtieme', 'vintiem'],
 ])
 def test_phonemicize(input, output):
     assert phonemicize(Token(input)) == output

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -103,6 +103,12 @@ from addok_fr.utils import phonemicize
     ['quimper', 'kinper'],
     ['georges', 'jeorj'],
     ['h', 'h'],
+    ['vallee', 'vale'],
+    ['montgriffon', 'mongrifon'],
+    ['montagne', 'montagn'],
+    ['montage', 'montaj'],
+    ['champs', 'chan'],
+    ['grandchamps', 'granchan'],
 ])
 def test_phonemicize(input, output):
     assert phonemicize(Token(input)) == output


### PR DESCRIPTION
Quelques exemples:
- montgriffon > mongrifon
- champs > chan
- gradchamps > granchan
